### PR TITLE
Add tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,51 @@
+name: Python lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint_langchain:
+    name: Lint LangChain - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./langchain
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "langchain/uv.lock"
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "langchain/pyproject.toml"
+      - name: Restore uv cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-langchain-${{ hashFiles('langchain/uv.lock') }}
+          restore-keys: |
+            uv-langchain-${{ hashFiles('langchain/uv.lock') }}
+            uv-${{ runner.os }}
+      - name: Install the project
+        run: uv sync --dev
+      - name: Run ruff format check
+        run: uv run ruff format --check
+      - name: Run ruff check
+        run: uv run ruff check
+      # - name: Run mypy
+      #   run: uv run mypy .
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.uv-cache
-          key: uv-langchain-${{ hashFiles('uv.lock') }}
+          key: uv-langchain-${{ hashFiles('langchain/uv.lock') }}
           restore-keys: |
-            uv-langchain-${{ hashFiles('uv.lock') }}
+            uv-langchain-${{ hashFiles('langchain/uv.lock') }}
       - name: Install the project
         run: uv sync --dev
       - name: Run unit tests

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -1,0 +1,50 @@
+name: Python tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-langchain:
+    name: LangChain Unit Tests - Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+            working-directory: ./langchain
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: "langchain/uv.lock"
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Restore uv cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-langchain-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-langchain-${{ hashFiles('uv.lock') }}
+      - name: Install the project
+        run: uv sync --dev
+      - name: Run unit tests
+        env:
+          VECTORIZE_TOKEN: ${{ secrets.VECTORIZE_TOKEN }}
+          VECTORIZE_ORG: ${{ secrets.VECTORIZE_ORG }}
+          VECTORIZE_ENV: dev
+        run: uv run pytest tests -vv
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/langchain/tests/test_retrievers.py
+++ b/langchain/tests/test_retrievers.py
@@ -1,28 +1,24 @@
 import json
 import logging
 import os
+import time
 from collections.abc import Iterator
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import pytest
+import urllib3
 import vectorize_client as v
+from vectorize_client import ApiClient
 
 from langchain_vectorize.retrievers import VectorizeRetriever
-
-
-@dataclass
-class TestContext:
-    api_client: v.ApiClient
-    api_token: str
-    org_id: str
 
 
 @pytest.fixture(scope="session")
 def api_token() -> str:
     token = os.getenv("VECTORIZE_TOKEN")
     if not token:
-        msg = "Please set VECTORIZE_TOKEN environment variable"
+        msg = "Please set the VECTORIZE_TOKEN environment variable"
         raise ValueError(msg)
     return token
 
@@ -31,21 +27,29 @@ def api_token() -> str:
 def org_id() -> str:
     org = os.getenv("VECTORIZE_ORG")
     if not org:
-        msg = "Please set VECTORIZE_ORG environment variable"
+        msg = "Please set the VECTORIZE_ORG environment variable"
         raise ValueError(msg)
     return org
 
 
 @pytest.fixture(scope="session")
-def api_client(api_token: str) -> Iterator[TestContext]:
+def environment() -> Literal["prod", "dev", "local", "staging"]:
     env = os.getenv("VECTORIZE_ENV", "prod")
+    if env not in ["prod", "dev", "local", "staging"]:
+        msg = "Invalid VECTORIZE_ENV environment variable."
+        raise ValueError(msg)
+    return env
+
+
+@pytest.fixture(scope="session")
+def api_client(api_token: str, environment: str) -> Iterator[ApiClient]:
     header_name = None
     header_value = None
-    if env == "prod":
+    if environment == "prod":
         host = "https://api.vectorize.io/v1"
-    elif env == "dev":
+    elif environment == "dev":
         host = "https://api-dev.vectorize.io/v1"
-    elif env == "local":
+    elif environment == "local":
         host = "http://localhost:3000/api"
         header_name = "x-lambda-api-key"
         header_value = api_token
@@ -86,8 +90,6 @@ def pipeline_id(api_client: v.ApiClient, org_id: str) -> Iterator[str]:
             metadata=json.dumps({"created-from-api": True}),
         ),
     )
-
-    import urllib3
 
     http = urllib3.PoolManager()
     this_dir = Path(__file__).parent
@@ -137,7 +139,9 @@ def pipeline_id(api_client: v.ApiClient, org_id: str) -> Iterator[str]:
                 config={},
             ),
             ai_platform=v.AIPlatformSchema(
-                id=builtin_ai_platform, type=v.AIPlatformType.VECTORIZE, config=v.AIPlatformConfigSchema()
+                id=builtin_ai_platform,
+                type=v.AIPlatformType.VECTORIZE,
+                config=v.AIPlatformConfigSchema(),
             ),
             pipeline_name="Test pipeline",
             schedule=v.ScheduleSchema(type=v.ScheduleSchemaType.MANUAL),
@@ -154,20 +158,48 @@ def pipeline_id(api_client: v.ApiClient, org_id: str) -> Iterator[str]:
         logging.exception("Failed to delete pipeline %s", pipeline_id)
 
 
-def test_retrieve_init_args(api_token: str, org_id: str, pipeline_id: str) -> None:
+def test_retrieve_init_args(
+    environment: Literal["prod", "dev", "local", "staging"],
+    api_token: str,
+    org_id: str,
+    pipeline_id: str,
+) -> None:
     retriever = VectorizeRetriever(
-        api_token=api_token, organization=org_id, pipeline_id=pipeline_id, num_results=2
-    )
-    docs = retriever.invoke(input="What are you?")
-    assert len(docs) == 2
-
-
-def test_retrieve_invoke_args(api_token: str, org_id: str, pipeline_id: str) -> None:
-    retriever = VectorizeRetriever(api_token=api_token)
-    docs = retriever.invoke(
-        input="What are you?",
+        environment=environment,
+        api_token=api_token,
         organization=org_id,
         pipeline_id=pipeline_id,
         num_results=2,
     )
-    assert len(docs) == 2
+    start = time.time()
+    while True:
+        docs = retriever.invoke(input="What are you?")
+        if len(docs) == 2:
+            break
+        if time.time() - start > 180:
+            msg = "Docs not retrieved in time"
+            raise RuntimeError(msg)
+        time.sleep(1)
+
+
+def test_retrieve_invoke_args(
+    environment: Literal["prod", "dev", "local", "staging"],
+    api_token: str,
+    org_id: str,
+    pipeline_id: str,
+) -> None:
+    retriever = VectorizeRetriever(environment=environment, api_token=api_token)
+    start = time.time()
+    while True:
+        docs = retriever.invoke(
+            input="What are you?",
+            organization=org_id,
+            pipeline_id=pipeline_id,
+            num_results=2,
+        )
+        if len(docs) == 2:
+            break
+        if time.time() - start > 180:
+            msg = "Docs not retrieved in time"
+            raise RuntimeError(msg)
+        time.sleep(1)

--- a/langchain/uv.lock
+++ b/langchain/uv.lock
@@ -307,7 +307,6 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -321,7 +320,6 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.9.0,<0.10" },
 ]
 
@@ -622,18 +620,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "0.25.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several key changes to the CI workflows and the `VectorizeRetriever` class, as well as updates to the test suite to accommodate new functionality. The most important changes include the addition of linting and testing workflows, enhancement of the `VectorizeRetriever` class to support different environments, and updates to the test cases to ensure they work with the new environment settings.

### CI Workflow Enhancements:
* Added a new GitHub Actions workflow for Python linting with support for Python versions 3.9 and 3.13. This workflow includes steps for setting up the environment, restoring cache, and running lint checks using `ruff`. (`.github/workflows/lint.yml`)
* Added a new GitHub Actions workflow for running Python tests with support for multiple Python versions (3.9 to 3.13). This workflow includes steps for setting up the environment, restoring cache, and running unit tests using `pytest`. (`.github/workflows/python_test.yml`)

### `VectorizeRetriever` Enhancements:
* Introduced an `environment` attribute to the `VectorizeRetriever` class, allowing it to operate in different environments such as "prod", "dev", "local", and "staging". (`langchain/langchain_vectorize/retrievers.py`)
* Updated the `model_post_init` method to configure the API client based on the specified environment, including setting custom headers for local development. (`langchain/langchain_vectorize/retrievers.py`)

### Test Suite Updates:
* Added an `environment` fixture to the test suite to provide the environment setting for tests. Updated the `api_client` fixture to use this environment setting. (`langchain/tests/test_retrievers.py`)
* Modified test cases to include the `environment` parameter and added a retry mechanism to ensure documents are retrieved within a specified time frame. (`langchain/tests/test_retrievers.py`)