### PR TITLE
Fix wheel packaging

### DIFF
--- a/langchain/pyproject.toml
+++ b/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langchain-vectorize"
-version = "0.0.2"
+version = "0.0.3"
 description = "An integration package connecting Vectorize and LangChain"
 readme = "README.md"
 keywords = ["langchain", "vectorize", "retrieval", "search"]
@@ -65,7 +65,7 @@ show_error_codes = true
 show_error_context = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["langchain-vectorize"]
+packages = ["langchain_vectorize"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
This pull request includes updates to the `langchain/pyproject.toml` file to increment the version number and correct the package name format.

Version update:

* [`langchain/pyproject.toml`](diffhunk://#diff-545a5ada58599796638bc144652ae6684159163aff6475dcb8d6b28b19f5d616L3-R3): Updated the version from "0.0.2" to "0.0.3".

Package name correction:

* [`langchain/pyproject.toml`](diffhunk://#diff-545a5ada58599796638bc144652ae6684159163aff6475dcb8d6b28b19f5d616L68-R68): Changed the package name from "langchain-vectorize" to "langchain_vectorize" under the `[tool.hatch.build.targets.wheel]` section.